### PR TITLE
Add stamen-terrain-background and stamen-terrain-lines as map provider

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -77,17 +77,19 @@ GeoTiler supports multiple map providers.
 
 The list of supported map providers is presented in the table below.
 
-    ========================= ===================== ==================
-         Provider                Provider Id           License
-    ========================= ===================== ==================
-     OpenStreetMap             osm                   `Open Data Commons Open Database License <http://www.openstreetmap.org/copyright>`_
-     OpenStreetMap Cycle       osm-cycle             as above
-     Stamen Toner              stamen-toner          `Creative Commons Attribution (CC BY 3.0) license <http://maps.stamen.com/>`_
-     Stamen Toner Lite         stamen-toner-lite     as above
-     Stamen Terrain            stamen-terrain        as above
-     Stamen Water Color        stamen-watercolor     as above
-     Modest Maps Blue Marble   bluemarble            see `NASA guideline <http://www.nasa.gov/audience/formedia/features/MP_Photo_Guidelines.html>`_
-    ========================= ===================== ==================
+    =========================== ========================= ==================
+         Provider                  Provider Id               License
+    =========================== ========================= ==================
+     OpenStreetMap               osm                       `Open Data Commons Open Database License <http://www.openstreetmap.org/copyright>`_
+     OpenStreetMap Cycle         osm-cycle                 as above
+     Stamen Toner                stamen-toner              `Creative Commons Attribution (CC BY 3.0) license <http://maps.stamen.com/>`_
+     Stamen Toner Lite           stamen-toner-lite         as above
+     Stamen Terrain              stamen-terrain            as above
+     Stamen Terrain Background   stamen-terrain-background as above
+     Stamen Terrain Lines        stamen-terrain-lines      as above
+     Stamen Water Color          stamen-watercolor         as above
+     Modest Maps Blue Marble     bluemarble                see `NASA guideline <http://www.nasa.gov/audience/formedia/features/MP_Photo_Guidelines.html>`_
+    =========================== ========================= ==================
 
 The default map provider is OpenStreetMap.
 

--- a/geotiler/source/stamen-terrain-background.json
+++ b/geotiler/source/stamen-terrain-background.json
@@ -1,0 +1,6 @@
+{
+    "name": "Stamen Terrain Background",
+    "attribution": "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.",
+    "url": "http://{subdomain}.tile.stamen.com/terrain-background/{z}/{x}/{y}.{ext}",
+    "subdomains": ["a", "b", "c", "d"]
+}

--- a/geotiler/source/stamen-terrain-lines.json
+++ b/geotiler/source/stamen-terrain-lines.json
@@ -1,0 +1,6 @@
+{
+    "name": "Stamen Terrain Lines",
+    "attribution": "Map tiles by Stamen Design, under CC BY 3.0. Data by OpenStreetMap, under ODbL.",
+    "url": "http://{subdomain}.tile.stamen.com/terrain-lines/{z}/{x}/{y}.{ext}",
+    "subdomains": ["a", "b", "c", "d"]
+}


### PR DESCRIPTION
I needed a map with terrain background and roads (lines) but without labels, so I added these providers.
I use them according to the following snippet.
``` python
lines = geotiler.Map(extent=bbox, zoom=12, provider="stamen-terrain-lines")
bg = geotiler.Map(extent=bbox, zoom=12, provider="stamen-terrain-background")

background = geotiler.render_map(bg)
foreground = geotiler.render_map(lines)
background.paste(foreground, (0, 0), foreground)
```