### PR TITLE
Add setuptools to install_requires in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     Pillow
     cytoolz >= 0.8.2
     aiohttp >= 2.3.5
+    setuptools
 
 [options.extras_require]
 tests = mypy; pytest-cov; pytest-timeout; pytest-asyncio; uvloop


### PR DESCRIPTION
This package does not work when installed in a clean chroot because it cannot import “pkg_resources”, which is distributed with setuptools.