### PR TITLE
Remove unneeded dep in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools",
-    "setuptools_git",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
It seems that we do not need setuptools_git dependency anymore. It was also not consistent with the cfg file.