### PR TITLE
Adjust dependencies for tests extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     setuptools
 
 [options.extras_require]
-tests = mypy; pytest-cov; pytest-timeout; pytest-asyncio; uvloop
+tests = mypy; pytest-cov; pytest-timeout; pytest-asyncio
 
 [tool:pytest]
 addopts=--cov geotiler --cov-report=term-missing

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     setuptools
 
 [options.extras_require]
-tests = mypy; pytest-cov; pytest-timeout; pytest-asyncio
+tests = mypy; pytest-cov; pytest-timeout; pytest-asyncio; numpy
 
 [tool:pytest]
 addopts=--cov geotiler --cov-report=term-missing


### PR DESCRIPTION
Drop `uvloop`, which seems to be unused.

Add `numpy`, which is imported directly in the test suite.

Tested with:

```
python3 -m venv _e
. _e/bin/activate
pip install -e .[tests]
pip install 'pillow<10'
python -m pytest
```