### PR TITLE
Make tests compatible with Python 3.14

### DIFF
--- a/geotiler/tests/test_cache.py
+++ b/geotiler/tests/test_cache.py
@@ -36,8 +36,10 @@ from geotiler.map import Tile
 from geotiler.cache import caching_downloader, redis_downloader
 
 from unittest import mock
+import pytest
 
-def test_redis_downloader_and_cache():
+@pytest.mark.asyncio
+async def test_redis_downloader_and_cache():
     """
     Test Redis downloader and cache functions.
     """
@@ -57,9 +59,8 @@ def test_redis_downloader_and_cache():
     urls = ['url1', 'url2', 'url3']
     tiles = [Tile(url, None, None, None) for url in urls]
 
-    loop = asyncio.get_event_loop()
     tiles = downloader(tiles, 2)
-    result = loop.run_until_complete(as_list(tiles))
+    result = await as_list(tiles)
 
     args = [v[0][0] for v in client.get.call_args_list]
     assert ['url1', 'url2', 'url3'] == args

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ doc =
 
 [tool:pytest]
 addopts=--cov geotiler --cov-report=term-missing
+asyncio_default_fixture_loop_scope = function
 
 [tool:coverage:report]
 show_missing=1


### PR DESCRIPTION
Starting with Python 3.14 `asyncio.get_event_loop()` no longer
implicitly creates an event loop. Instead it raises a RuntimeError
when there is no current event loop.

Also set `asyncio_default_fixture_loop_scope` explicitly as
recommended.
